### PR TITLE
Use the end stream to stop extra values

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,8 @@
 var flyd = require('flyd')
 
 module.exports = function (stream$) {
-  var executed = false
   return flyd.combine(function (s$, self) {
-    if (!executed) {
-      executed = true
-      self(s$())
-    }
+    self(s$())
+    self.end(true);
   }, [stream$])
 }


### PR DESCRIPTION
In stead of running the `if (!executed)` check every time the parent stream is updated a better approach is to use the end stream.